### PR TITLE
remove non-meaningful version display

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -22,6 +22,8 @@ under the License.
 
 <!-- N.B. all non-body elements are automatically inherited -->
 
+  <version position="none" /><!-- no version display on unversioned part of the site -->
+
   <skin>
     <groupId>org.apache.httpcomponents</groupId>
     <artifactId>maven-site-skin</artifactId>


### PR DESCRIPTION
this site is not versioned: displaying a version, with always `1-SNAPSHOT` value, has no meaning