### PR TITLE
prepare generated documentation integration: LATEST staging+releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
   <packaging>pom</packaging>
 
   <scm>
-    <connection>scm:git:https://gitbox.apache.org/repos/asf/httpcomponents-parent.git</connection>
-    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/httpcomponents-parent.git</developerConnection>
-    <url>https://github.com/apache/httpcomponents-parent/tree/${project.scm.tag}</url>
+    <connection>scm:git:https://gitbox.apache.org/repos/asf/httpcomponents-website.git</connection>
+    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/httpcomponents-website.git</developerConnection>
+    <url>https://github.com/apache/httpcomponents-website/tree/${project.scm.tag}</url>
     <tag>master</tag>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,8 @@
         <configuration>
           <content>${project.reporting.outputDirectory}</content><!-- no need for site:stage, use target/site -->
           <ignorePathsToDelete><!-- don't delete content until site svnpubsub location refactoring done -->
+            <ignorePathsToDelete>components</ignorePathsToDelete>
             <ignorePathsToDelete>*.html</ignorePathsToDelete>
-            <ignorePathsToDelete>doc</ignorePathsToDelete>
             <ignorePathsToDelete>apidocs</ignorePathsToDelete>
             <ignorePathsToDelete>xref</ignorePathsToDelete>
             <ignorePathsToDelete>xref-test</ignorePathsToDelete>
@@ -123,6 +123,34 @@
             <goals>
               <goal>publish-scm</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>1.10.9</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>link-components</id>
+            <phase>site</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <!-- links to components directories containing documentation generated from code -->
+                <symlink action="recreate" overwrite="true">
+                  <fileset dir="${project.reporting.outputDirectory}" includes="**/documentation.links"/>  
+                </symlink>
+              </target>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/site/resources/httpcomponents-client-5.0.x/documentation.links
+++ b/src/site/resources/httpcomponents-client-5.0.x/documentation.links
@@ -1,0 +1,7 @@
+# links property file for Ant's symlink task in pom.xml:
+# links to components in http://hc.apache.org/components/
+LATEST   ../components/httpcomponents-client-5.0.x/LATEST
+
+# sample future release, once it has been released and
+# its documentation has been versioned from LATEST staging with something like "svn cp https://svn.apache.org/repos/asf/httpcomponents/site/components/httpcomponents-client-5.0.x/LATEST https://svn.apache.org/repos/asf/httpcomponents/site/components/httpcomponents-client-5.0.x/5.0.3"
+5.1-beta-3   ../components/httpcomponents-client-5.0.x/5.0.3

--- a/src/site/resources/httpcomponents-core-5.1.x/documentation.links
+++ b/src/site/resources/httpcomponents-core-5.1.x/documentation.links
@@ -1,0 +1,7 @@
+# links property file for Ant's symlink task in pom.xml:
+# links to components in http://hc.apache.org/components/
+LATEST   ../components/httpcomponents-core-5.1.x/LATEST
+
+# sample future release, once it has been released and
+# its documentation has been versioned from LATEST staging with something like "svn cp https://svn.apache.org/repos/asf/httpcomponents/site/components/httpcomponents-core-5.1.x/LATEST https://svn.apache.org/repos/asf/httpcomponents/site/components/httpcomponents-core-5.1.x/5.1-beta-3"
+5.1-beta-3   ../components/httpcomponents-core-5.1.x/5.1-beta-3

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -23,11 +23,12 @@ under the License.
 <!-- N.B. all non-body elements are automatically inherited -->
 
   <version position="none" /><!-- no version display on unversioned part of the site -->
+  <edit>${project.scm.url}</edit>
 
   <skin>
-    <groupId>org.apache.httpcomponents</groupId>
-    <artifactId>maven-site-skin</artifactId>
-    <version>1.1</version>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.9</version>
   </skin>
 
   <bannerLeft>
@@ -43,10 +44,13 @@ under the License.
   </bannerRight>
 
   <body>
+    <breadcrumbs>
+      <item name="HttpComponents" href="http://hc.apache.org/index.html"/>
+    </breadcrumbs>
+
     <!-- N.B. body links are automatically inherited -->
     <links>
       <item name="Apache" href="http://www.apache.org/"/>
-      <item name="HttpComponents" href="http://hc.apache.org/index.html"/>
     </links>
     
     <!-- add standard menu links for all sub-sites -->
@@ -150,5 +154,8 @@ under the License.
       <br/>
       <div class="xleft">All other marks mentioned may be trademarks or registered trademarks of their respective owners.</div>
     </footer>
+    <fluidoSkin>
+      <skipGenerationDate>true</skipGenerationDate>
+    </fluidoSkin>
   </custom>
 </project>


### PR DESCRIPTION
this is the glue of PRs http-client https://github.com/apache/httpcomponents-client/pull/280 and http-core https://github.com/apache/httpcomponents-core/pull/252 into main website

the antrun symlink is the glue that permits flexible linking when copying evolving code-generated documentation in LATEST to versioned state during release process