### PR TITLE
Update link to multiplexed http/2 exchanges example

### DIFF
--- a/src/site/markdown/httpcomponents-client-5.3.x/examples-async.md
+++ b/src/site/markdown/httpcomponents-client-5.3.x/examples-async.md
@@ -49,7 +49,7 @@ HttpClient Examples (Async)
   This example demonstrates how to use a custom execution interceptor to add trailers to all outgoing request enclosing
   an entity..
 
-- [Multiplexed HTTP/2 exchanges](https://github.com/apache/httpcomponents-client/tree/5.3.x/httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientHttp2ServerPush.java)
+- [Multiplexed HTTP/2 exchanges](https://github.com/apache/httpcomponents-client/tree/5.3.x/httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientH2ServerPush.java)
 
 This example demonstrates handling of HTTP/2 message exchanges pushed by the server.
 


### PR DESCRIPTION
Update the link to example in the doc since it has been renamed from AsyncClientHttp2ServerPush.java to AsyncClientH2ServerPush.java