### PR TITLE
Minor corrections around cookie spec in the migration guides

### DIFF
--- a/src/site/markdown/httpcomponents-client-5.4.x/migration-guide/migration-to-classic.md
+++ b/src/site/markdown/httpcomponents-client-5.4.x/migration-guide/migration-to-classic.md
@@ -59,7 +59,7 @@ management configuration, SSL/TLS and timeout settings when building HttpClient 
          .build();
    ```
 
--  Favor `standard-strict` cookie policy when using HttpClient 5.0.
+-  Favor the `strict` cookie policy when using HttpClient 5.0.
 
 -  Use response timeout to define the maximum period of inactivity until receipt of response data.
 

--- a/src/site/markdown/httpcomponents-client-5.4.x/migration-guide/preparation.md
+++ b/src/site/markdown/httpcomponents-client-5.4.x/migration-guide/preparation.md
@@ -18,7 +18,7 @@ It is strongly encouraged to follow the best practices and common use patterns i
 
 1. Set finite connection total time to live (TTL).
 
-1. Favor `standard` and `standard-strict` cookie policies.
+1. Favor the `strict` cookie policy.
 
 1. IMPORTANT: Always re-use `CloseableHttpClient` instances. They are expensive to create, but they are also fully
    thread safe, so multiple threads can use the same instance of `CloseableHttpClient` to execute multiple requests
@@ -38,7 +38,7 @@ It is strongly encouraged to follow the best practices and common use patterns i
             .setDefaultRequestConfig(RequestConfig.custom()
                     .setConnectTimeout(60000)
                     .setSocketTimeout(60000)
-                    .setCookieSpec(CookieSpecs.STANDARD_STRICT)
+                    .setCookieSpec(StandardCookieSpec.STRICT)
                     .build())
             .build();
     ```   
@@ -62,7 +62,7 @@ It is strongly encouraged to follow the best practices and common use patterns i
     clientContext.setRequestConfig(RequestConfig.custom()
             .setConnectTimeout(60000)
             .setSocketTimeout(60000)
-            .setCookieSpec(CookieSpecs.STANDARD)
+            .setCookieSpec(StandardCookieSpec.STRICT)
             .build());
     ```
 


### PR DESCRIPTION
I've noticed the examples are not up to date but I limited this PR to the cookie errors.  For example, the method `HttpClientBuilder:: setSSLSocketFactory` does not exist anymore, just like `RequestConfig::setSocketTimeout` with a long value. 

Related PR : https://github.com/apache/httpcomponents-client/pull/197/files