### PR TITLE
doc: Minor typo around scope

### DIFF
--- a/src/site/markdown/httpcomponents-client-5.4.x/migration-guide/migration-to-async-simple.md
+++ b/src/site/markdown/httpcomponents-client-5.4.x/migration-guide/migration-to-async-simple.md
@@ -119,8 +119,8 @@ either known to be well-behaved or specifically designed for simple message hand
    
    });
    ```    
--  `CloseableHttpAsyncClient` instances should be closed when no longer needed or about to go out of score.
+-  `CloseableHttpAsyncClient` instances should be closed when no longer needed or about to go out of scope.
 
    ```java
    client.close(CloseMode.GRACEFUL);
-   ```       
+   ```

--- a/src/site/markdown/httpcomponents-client-5.4.x/migration-guide/migration-to-classic.md
+++ b/src/site/markdown/httpcomponents-client-5.4.x/migration-guide/migration-to-classic.md
@@ -116,7 +116,7 @@ management configuration, SSL/TLS and timeout settings when building HttpClient 
    System.out.println(responseData);
    ```
 
--  `CloseableHttpClient` instances should be closed when no longer needed or about to go out of score.
+-  `CloseableHttpClient` instances should be closed when no longer needed or about to go out of scope.
 
    ```java
    client.close();

--- a/src/site/markdown/httpcomponents-client-5.4.x/migration-guide/preparation.md
+++ b/src/site/markdown/httpcomponents-client-5.4.x/migration-guide/preparation.md
@@ -106,7 +106,7 @@ It is strongly encouraged to follow the best practices and common use patterns i
     });
     System.out.println(responseData);
     ```
-1. `CloseableHttpClient` instances should be closed when no longer needed or about to go out of score.
+1. `CloseableHttpClient` instances should be closed when no longer needed or about to go out of scope.
 
     ```java
     client.close();


### PR DESCRIPTION
Corrects the phrase "out of score" to "out of scope" which I believe is what was intended for cleaning up the client.