### PR TITLE
doc: Highlight subtle potentially breaking new url normalization behaviour

### DIFF
--- a/src/site/markdown/httpcomponents-client-5.4.x/migration-guide/migration-to-classic.md
+++ b/src/site/markdown/httpcomponents-client-5.4.x/migration-guide/migration-to-classic.md
@@ -4,7 +4,7 @@ HttpClient 5.x releases can be co-located with earlier major versions on the sam
 namespace and Maven module coordinates.
 
 HttpClient 5.x classic APIs are largely compatible with HttpClient 4.0 APIs. Major differences are related to connection
-management configuration, SSL/TLS and timeout settings when building HttpClient instances.
+management configuration, SSL/TLS and timeout settings when building HttpClient instances. There are also some important differences with URL normalization and encoding.
 
 ## Migration steps
 
@@ -121,3 +121,5 @@ management configuration, SSL/TLS and timeout settings when building HttpClient 
    ```java
    client.close();
    ```
+
+- The 4.x `RequestConfig` property `normalizeUri` has been removed, and the 4.x `URIUtils.normalizeSyntax` is no longer public. In 4.x, these only supported limited normalization from [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) including removal of dot segments (section 5.2.4), and syntax-based normalization (section 6.2.2). The 5.x `URIBuilder` in [httpcomponents-core](https://hc.apache.org/httpcomponents-core-5.3.x/index.html) has a new public `normalizeSyntax` method, but it strives for more thorough support of [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), specifically percent-encoding all components. Since 5.3, `normalizeSyntax` has been deprecated and renamed to `optimize` to emphasize the difference in behaviour.

--- a/src/site/markdown/httpcomponents-client-5.4.x/migration-guide/migration-to-classic.md
+++ b/src/site/markdown/httpcomponents-client-5.4.x/migration-guide/migration-to-classic.md
@@ -4,7 +4,8 @@ HttpClient 5.x releases can be co-located with earlier major versions on the sam
 namespace and Maven module coordinates.
 
 HttpClient 5.x classic APIs are largely compatible with HttpClient 4.0 APIs. Major differences are related to connection
-management configuration, SSL/TLS and timeout settings when building HttpClient instances. There are also some important differences with URL normalization and encoding.
+management configuration, SSL/TLS and timeout settings when building HttpClient instances. 
+There are also some important differences with URL normalization and encoding.
 
 ## Migration steps
 
@@ -122,4 +123,10 @@ management configuration, SSL/TLS and timeout settings when building HttpClient 
    client.close();
    ```
 
-- The 4.x `RequestConfig` property `normalizeUri` has been removed, and the 4.x `URIUtils.normalizeSyntax` is no longer public. In 4.x, these only supported limited normalization from [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) including removal of dot segments (section 5.2.4), and syntax-based normalization (section 6.2.2). The 5.x `URIBuilder` in [httpcomponents-core](https://hc.apache.org/httpcomponents-core-5.3.x/index.html) has a new public `normalizeSyntax` method, but it strives for more thorough support of [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), specifically percent-encoding all components. Since 5.3, `normalizeSyntax` has been deprecated and renamed to `optimize` to emphasize the difference in behaviour.
+- The 4.x `RequestConfig` property `normalizeUri` has been removed, and `URIUtils.normalizeSyntax` is no longer public.
+ In 4.x, these only supported limited normalization from [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) 
+including removal of dot segments (section 5.2.4), and syntax-based normalization (section 6.2.2). 
+The 5.x `URIBuilder` in [httpcomponents-core](https://hc.apache.org/httpcomponents-core-5.3.x/index.html) has a new 
+public `normalizeSyntax` method, but it strives for more thorough support of RFC 3986, 
+specifically percent-encoding all components. 
+Since 5.3, `normalizeSyntax` has been deprecated and renamed to `optimize` to emphasize the difference in behaviour.


### PR DESCRIPTION
Folks upgrading 4.x url normalization code to 5.x may inadvertently (and in my team's case did) introduce a breaking change with their URLs due to the introduction of percent-encoding. This should be made clear in the migration guide.

Happy to rewrite/restructure anything here as needed - either in a new section, or a new page, if desired.